### PR TITLE
Improved clipboard integration and added EMI recipe tree support

### DIFF
--- a/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardScreenUtils.java
+++ b/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardScreenUtils.java
@@ -1,10 +1,16 @@
 package net.liukrast.schematicdisplay.clipboard;
 
+import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.equipment.clipboard.ClipboardEntry;
+import dev.emi.emi.api.EmiApi;
+import dev.emi.emi.api.stack.Comparison;
 import dev.emi.emi.api.stack.EmiStack;
-import dev.emi.emi.runtime.EmiFavorite;
-import dev.emi.emi.runtime.EmiFavorites;
+import dev.emi.emi.bom.BoM;
+import net.liukrast.schematicdisplay.EMICreateSchematics;
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 
@@ -14,37 +20,93 @@ import java.util.List;
 
 public final class ClipboardScreenUtils {
     public static final String REAL_COUNT_KEY = "CreateEMISchematicsData";
+    public static final String VIRTUAL_RECIPE_KEY = "CreateEMISchematicsVirtualRecipe";
+    private static long emi_create_schematics$recipeCounter = 0;
+
     private ClipboardScreenUtils() {}
 
     public static void load(List<List<ClipboardEntry>> pages) {
-        List<ClipboardEntry> allEntries = new ArrayList<>();
-        for(var page : pages)
-            allEntries.addAll(page);
-        allEntries.sort(Comparator.comparingInt((ClipboardEntry entry) -> entry.itemAmount).reversed());
+        List<EntryAmount> remainingEntries = collectRemainingEntries(pages);
+        if (remainingEntries.isEmpty()) {
+            notifyEmptyTree();
+            return;
+        }
 
-        var copiedList = new ArrayList<>(EmiFavorites.favorites);
+        List<EmiStack> inputs = new ArrayList<>(remainingEntries.size());
+        for (EntryAmount entry : remainingEntries) {
+            inputs.add(EmiStack.of(entry.stack.copy()).setAmount(entry.amount));
+        }
 
-        copiedList.stream()
-                .filter(fav -> {
-                    if(!(fav.getStack() instanceof EmiStack stack)) return false;
-                    var data = stack.getItemStack().getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
+        ClipboardTreeRecipe recipe = new ClipboardTreeRecipe(
+                inputs,
+                createVirtualOutput(),
+                nextVirtualRecipeId()
+        );
 
-                    if(data.isEmpty()) return false;
-                    return data.contains(REAL_COUNT_KEY);
-                })
-                .forEach(EmiFavorites::removeFavorite);
+        BoM.setGoal(recipe);
+        BoM.craftingMode = true;
 
-        for(var entry : allEntries) {
-            ItemStack stack1 = entry.icon.copy();
-            stack1.update(DataComponents.CUSTOM_DATA, CustomData.EMPTY, existingData ->
-                    existingData.update(tag -> tag.putLong(REAL_COUNT_KEY, entry.itemAmount))
+        Minecraft minecraft = Minecraft.getInstance();
+        minecraft.setScreen(null);
+        EmiApi.viewRecipeTree();
+    }
+
+    private static List<EntryAmount> collectRemainingEntries(List<List<ClipboardEntry>> pages) {
+        List<EntryAmount> mergedEntries = new ArrayList<>();
+        for (List<ClipboardEntry> page : pages) {
+            for (ClipboardEntry entry : page) {
+                if (entry.checked || entry.icon.isEmpty() || entry.itemAmount <= 0) {
+                    continue;
+                }
+                mergeEntry(mergedEntries, entry.icon, entry.itemAmount);
+            }
+        }
+        mergedEntries.sort(Comparator.comparingLong((EntryAmount entry) -> entry.amount).reversed());
+        return mergedEntries;
+    }
+
+    private static void mergeEntry(List<EntryAmount> mergedEntries, ItemStack stack, long amount) {
+        for (EntryAmount entry : mergedEntries) {
+            if (ItemStack.isSameItemSameComponents(entry.stack, stack)) {
+                entry.amount += amount;
+                return;
+            }
+        }
+        mergedEntries.add(new EntryAmount(stack.copy(), amount));
+    }
+
+    private static EmiStack createVirtualOutput() {
+        ItemStack stack = AllBlocks.CLIPBOARD.asStack();
+        stack.set(DataComponents.CUSTOM_NAME, Component.translatable("gui." + EMICreateSchematics.MOD_ID + ".clipboard.tree_output"));
+        stack.update(DataComponents.CUSTOM_DATA, CustomData.EMPTY,
+                existingData -> existingData.update(tag -> tag.putBoolean(VIRTUAL_RECIPE_KEY, true)));
+        return EmiStack.of(stack).comparison(Comparison.compareComponents());
+    }
+
+    private static ResourceLocation nextVirtualRecipeId() {
+        return ResourceLocation.fromNamespaceAndPath(
+                EMICreateSchematics.MOD_ID,
+                "/clipboard/" + emi_create_schematics$recipeCounter++
+        );
+    }
+
+    private static void notifyEmptyTree() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player != null) {
+            minecraft.player.displayClientMessage(
+                    Component.translatable("gui." + EMICreateSchematics.MOD_ID + ".clipboard.tree_empty"),
+                    true
             );
-            EmiStack emiStack = EmiStack.of(stack1);
-            emiStack.setAmount(1);
+        }
+    }
 
+    private static final class EntryAmount {
+        private final ItemStack stack;
+        private long amount;
 
-
-            if(!entry.checked) EmiFavorites.addFavorite(emiStack);
+        private EntryAmount(ItemStack stack, long amount) {
+            this.stack = stack;
+            this.amount = amount;
         }
     }
 }

--- a/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardTreeRecipe.java
+++ b/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardTreeRecipe.java
@@ -15,6 +15,7 @@ import java.util.List;
 public final class ClipboardTreeRecipe extends BasicEmiRecipe {
     private static final int DISPLAYED_INPUTS = 9;
     private final Component overflowLabel;
+    private boolean completed;
 
     public ClipboardTreeRecipe(List<EmiStack> inputs, EmiStack output, ResourceLocation id) {
         super(VanillaEmiRecipeCategories.CRAFTING, id, 118, 72);
@@ -29,6 +30,18 @@ public final class ClipboardTreeRecipe extends BasicEmiRecipe {
 
     public static boolean isVirtual(EmiRecipe recipe) {
         return recipe instanceof ClipboardTreeRecipe;
+    }
+
+    public static ClipboardTreeRecipe getVirtual(EmiRecipe recipe) {
+        return recipe instanceof ClipboardTreeRecipe virtual ? virtual : null;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void markCompleted() {
+        completed = true;
     }
 
     @Override

--- a/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardTreeRecipe.java
+++ b/src/main/java/net/liukrast/schematicdisplay/clipboard/ClipboardTreeRecipe.java
@@ -1,0 +1,63 @@
+package net.liukrast.schematicdisplay.clipboard;
+
+import dev.emi.emi.api.recipe.BasicEmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import net.liukrast.schematicdisplay.EMICreateSchematics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+
+public final class ClipboardTreeRecipe extends BasicEmiRecipe {
+    private static final int DISPLAYED_INPUTS = 9;
+    private final Component overflowLabel;
+
+    public ClipboardTreeRecipe(List<EmiStack> inputs, EmiStack output, ResourceLocation id) {
+        super(VanillaEmiRecipeCategories.CRAFTING, id, 118, 72);
+        this.inputs.addAll(inputs);
+        this.outputs.add(output);
+
+        int hiddenInputs = Math.max(0, inputs.size() - DISPLAYED_INPUTS);
+        overflowLabel = hiddenInputs > 0
+                ? Component.translatable("gui." + EMICreateSchematics.MOD_ID + ".clipboard.tree_more", hiddenInputs)
+                : Component.empty();
+    }
+
+    public static boolean isVirtual(EmiRecipe recipe) {
+        return recipe instanceof ClipboardTreeRecipe;
+    }
+
+    @Override
+    public boolean hideCraftable() {
+        return true;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        widgets.addText(
+                Component.translatable("gui." + EMICreateSchematics.MOD_ID + ".clipboard.tree_recipe"),
+                0,
+                0,
+                0x404040,
+                false
+        );
+        widgets.addTexture(EmiTexture.EMPTY_ARROW, 60, 22);
+
+        for (int i = 0; i < DISPLAYED_INPUTS; i++) {
+            if (i < inputs.size()) {
+                widgets.addSlot(inputs.get(i), i % 3 * 18, 12 + i / 3 * 18);
+            } else {
+                widgets.addSlot(i % 3 * 18, 12 + i / 3 * 18);
+            }
+        }
+
+        widgets.addSlot(outputs.get(0), 92, 18).large(true).recipeContext(this);
+        if (!overflowLabel.getString().isEmpty()) {
+            widgets.addText(overflowLabel, 0, 62, 0x787878, false);
+        }
+    }
+}

--- a/src/main/java/net/liukrast/schematicdisplay/mixin/BoMScreenMixin.java
+++ b/src/main/java/net/liukrast/schematicdisplay/mixin/BoMScreenMixin.java
@@ -1,0 +1,41 @@
+package net.liukrast.schematicdisplay.mixin;
+
+import dev.emi.emi.bom.BoM;
+import dev.emi.emi.bom.MaterialNode;
+import dev.emi.emi.bom.ProgressState;
+import dev.emi.emi.screen.BoMScreen;
+import net.liukrast.schematicdisplay.clipboard.ClipboardTreeRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BoMScreen.class)
+public abstract class BoMScreenMixin {
+    @Inject(method = "recalculateTree", at = @At("TAIL"), remap = false)
+    private void emi_create_schematics$markVirtualRootProgress(CallbackInfo ci) {
+        if (BoM.tree == null || !ClipboardTreeRecipe.isVirtual(BoM.tree.goal.recipe) || BoM.tree.goal.children == null) {
+            return;
+        }
+
+        boolean anyProgress = false;
+        boolean allComplete = !BoM.tree.goal.children.isEmpty();
+
+        for (MaterialNode child : BoM.tree.goal.children) {
+            if (child.progress != ProgressState.UNSTARTED) {
+                anyProgress = true;
+            }
+            if (child.progress != ProgressState.COMPLETED) {
+                allComplete = false;
+            }
+        }
+
+        if (allComplete) {
+            BoM.tree.goal.progress = ProgressState.COMPLETED;
+        } else if (anyProgress) {
+            BoM.tree.goal.progress = ProgressState.PARTIAL;
+        } else {
+            BoM.tree.goal.progress = ProgressState.UNSTARTED;
+        }
+    }
+}

--- a/src/main/java/net/liukrast/schematicdisplay/mixin/BoMScreenMixin.java
+++ b/src/main/java/net/liukrast/schematicdisplay/mixin/BoMScreenMixin.java
@@ -5,6 +5,7 @@ import dev.emi.emi.bom.MaterialNode;
 import dev.emi.emi.bom.ProgressState;
 import dev.emi.emi.screen.BoMScreen;
 import net.liukrast.schematicdisplay.clipboard.ClipboardTreeRecipe;
+import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,7 +15,23 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class BoMScreenMixin {
     @Inject(method = "recalculateTree", at = @At("TAIL"), remap = false)
     private void emi_create_schematics$markVirtualRootProgress(CallbackInfo ci) {
-        if (BoM.tree == null || !ClipboardTreeRecipe.isVirtual(BoM.tree.goal.recipe) || BoM.tree.goal.children == null) {
+        if (BoM.tree == null) {
+            return;
+        }
+
+        ClipboardTreeRecipe virtualRecipe = ClipboardTreeRecipe.getVirtual(BoM.tree.goal.recipe);
+        if (virtualRecipe == null || BoM.tree.goal.children == null) {
+            return;
+        }
+
+        if (!virtualRecipe.isCompleted() && Minecraft.getInstance().player != null
+                && dev.emi.emi.api.recipe.EmiPlayerInventory.of(Minecraft.getInstance().player).canCraft(virtualRecipe)) {
+            virtualRecipe.markCompleted();
+            BoM.craftingMode = false;
+        }
+
+        if (virtualRecipe.isCompleted()) {
+            emi_create_schematics$completeNode(BoM.tree.goal);
             return;
         }
 
@@ -36,6 +53,16 @@ public abstract class BoMScreenMixin {
             BoM.tree.goal.progress = ProgressState.PARTIAL;
         } else {
             BoM.tree.goal.progress = ProgressState.UNSTARTED;
+        }
+    }
+
+    private void emi_create_schematics$completeNode(MaterialNode node) {
+        node.progress = ProgressState.COMPLETED;
+        if (node.children == null) {
+            return;
+        }
+        for (MaterialNode child : node.children) {
+            emi_create_schematics$completeNode(child);
         }
     }
 }

--- a/src/main/java/net/liukrast/schematicdisplay/mixin/ClipboardScreenMixin.java
+++ b/src/main/java/net/liukrast/schematicdisplay/mixin/ClipboardScreenMixin.java
@@ -33,7 +33,7 @@ public abstract class ClipboardScreenMixin extends AbstractSimiScreen {
     private void init(CallbackInfo ci) {
         final int x = guiLeft;
         final int y = guiTop - 8;
-        final IconButton customButton = new IconButton(x + 234, y + 197, AllIcons.I_WHITELIST).withCallback(() -> ClipboardScreenUtils.load(pages));
+        final IconButton customButton = new IconButton(x + 234, y + 197, AllIcons.I_SCHEMATIC).withCallback(() -> ClipboardScreenUtils.load(pages));
         customButton.setToolTip(emi_create_schematics$TOOLTIP);
         this.addRenderableWidget(customButton);
     }

--- a/src/main/java/net/liukrast/schematicdisplay/mixin/EmiFavoritesMixin.java
+++ b/src/main/java/net/liukrast/schematicdisplay/mixin/EmiFavoritesMixin.java
@@ -1,0 +1,22 @@
+package net.liukrast.schematicdisplay.mixin;
+
+import dev.emi.emi.api.recipe.EmiPlayerInventory;
+import dev.emi.emi.bom.BoM;
+import dev.emi.emi.runtime.EmiFavorites;
+import net.liukrast.schematicdisplay.clipboard.ClipboardTreeRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EmiFavorites.class)
+public abstract class EmiFavoritesMixin {
+    @Inject(method = "updateSynthetic", at = @At("TAIL"), remap = false)
+    private static void emi_create_schematics$hideVirtualRootRecipe(EmiPlayerInventory inv, CallbackInfo ci) {
+        if (BoM.tree == null || !ClipboardTreeRecipe.isVirtual(BoM.tree.goal.recipe)) {
+            return;
+        }
+
+        EmiFavorites.syntheticFavorites.removeIf(favorite -> ClipboardTreeRecipe.isVirtual(favorite.getRecipe()));
+    }
+}

--- a/src/main/java/net/liukrast/schematicdisplay/mixin/EmiFavoritesMixin.java
+++ b/src/main/java/net/liukrast/schematicdisplay/mixin/EmiFavoritesMixin.java
@@ -13,10 +13,25 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class EmiFavoritesMixin {
     @Inject(method = "updateSynthetic", at = @At("TAIL"), remap = false)
     private static void emi_create_schematics$hideVirtualRootRecipe(EmiPlayerInventory inv, CallbackInfo ci) {
-        if (BoM.tree == null || !ClipboardTreeRecipe.isVirtual(BoM.tree.goal.recipe)) {
+        if (BoM.tree == null) {
             return;
         }
 
-        EmiFavorites.syntheticFavorites.removeIf(favorite -> ClipboardTreeRecipe.isVirtual(favorite.getRecipe()));
+        ClipboardTreeRecipe virtualRecipe = ClipboardTreeRecipe.getVirtual(BoM.tree.goal.recipe);
+        if (virtualRecipe == null) {
+            return;
+        }
+
+        if (!virtualRecipe.isCompleted() && inv.canCraft(virtualRecipe)) {
+            virtualRecipe.markCompleted();
+            BoM.craftingMode = false;
+        }
+
+        if (virtualRecipe.isCompleted()) {
+            EmiFavorites.syntheticFavorites.clear();
+            return;
+        }
+
+        EmiFavorites.syntheticFavorites.removeIf(favorite -> favorite.getRecipe() == virtualRecipe);
     }
 }

--- a/src/main/resources/assets/emi_create_schematics/lang/en_us.json
+++ b/src/main/resources/assets/emi_create_schematics/lang/en_us.json
@@ -1,3 +1,7 @@
 {
-  "gui.emi_create_schematics.clipboard.favourite": "Transfer all items to EMI Favourites"
+  "gui.emi_create_schematics.clipboard.favourite": "Open the EMI recipe tree from this clipboard",
+  "gui.emi_create_schematics.clipboard.tree_empty": "No unchecked item requirements were found on this clipboard",
+  "gui.emi_create_schematics.clipboard.tree_output": "Schematic Materials",
+  "gui.emi_create_schematics.clipboard.tree_recipe": "Clipboard Checklist",
+  "gui.emi_create_schematics.clipboard.tree_more": "+%s more"
 }

--- a/src/main/resources/assets/emi_create_schematics/lang/it_it.json
+++ b/src/main/resources/assets/emi_create_schematics/lang/it_it.json
@@ -1,3 +1,7 @@
 {
-  "gui.emi_create_schematics.clipboard.favourite": "Trasferisci tutti gli item nei preferiti di EMI"
+  "gui.emi_create_schematics.clipboard.favourite": "Apri l'albero ricette di EMI da questa clipboard",
+  "gui.emi_create_schematics.clipboard.tree_empty": "Nessun requisito oggetto non spuntato trovato su questa clipboard",
+  "gui.emi_create_schematics.clipboard.tree_output": "Materiali dello schema",
+  "gui.emi_create_schematics.clipboard.tree_recipe": "Checklist della clipboard",
+  "gui.emi_create_schematics.clipboard.tree_more": "+%s altri"
 }

--- a/src/main/resources/emi_create_schematics.mixins.json
+++ b/src/main/resources/emi_create_schematics.mixins.json
@@ -8,7 +8,9 @@
     "ItemEmiStackMixin"
   ],
   "client": [
-    "ClipboardScreenMixin"
+    "BoMScreenMixin",
+    "ClipboardScreenMixin",
+    "EmiFavoritesMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
# Summary

This PR changes the clipboard integration from EMI favourites to an EMI recipe tree workflow.

Unchecked clipboard entries are now merged into a virtual root recipe and opened directly in EMI's recipe tree, which makes it much easier to follow schematic material dependencies from a single entry point.

It also adjusts progress handling for that virtual root so the tree focuses on the actual child crafts and remaining materials instead of treating the synthetic top-level recipe as a real craft target.

# Changes

- replaced the clipboard action with direct EMI recipe tree creation
- added a virtual clipboard recipe used as the tree root
- merged duplicate clipboard entries before building the tree
- hid the synthetic root task from EMI's synthetic favourites list
- updated tree root progress so completion follows child material progress
- refreshed button tooltip and localization strings for the new behavior

# Testing

- ran `bash ./gradlew build`

# Screenshot

<img width="1710" height="715" alt="image" src="https://github.com/user-attachments/assets/f6b9f1b3-5115-4b78-9f3d-bf92da666087" />
<img width="1676" height="656" alt="image" src="https://github.com/user-attachments/assets/1afab1f0-23ee-44e3-9ae0-e8ef09193a66" />


## Tips

This PR was generated with AI assistance. If you do not like it, feel free to close it directly.